### PR TITLE
Add clear events, chat notification event

### DIFF
--- a/conditions.go
+++ b/conditions.go
@@ -212,6 +212,7 @@ type ConditionChannelChatMessageDelete struct {
 }
 
 type ConditionChannelChatNotification struct {
+	// User ID of the channel to receive chat notification events for.
 	BroadcasterUserID string `json:"broadcaster_user_id"`
 	// The user ID to read chat as.
 	UserID string `json:"user_id,omitempty"`

--- a/conditions.go
+++ b/conditions.go
@@ -189,3 +189,30 @@ type ConditionUserUpdate struct {
 	// The user ID for the user you want update notifications for.
 	UserID string `json:"user_id"`
 }
+
+type ConditionChannelChatClear struct {
+	// User ID of the channel to receive chat clear events for.
+	BroadcasterUserID string `json:"broadcaster_user_id"`
+	// The user ID to read chat as.
+	UserID string `json:"user_id"`
+}
+
+type ConditionChannelChatClearUserMessages struct {
+	// User ID of the channel to receive chat clear events for.
+	BroadcasterUserID string `json:"broadcaster_user_id"`
+	// The user ID to read chat as.
+	UserID string `json:"user_id"`
+}
+
+type ConditionChannelChatMessageDelete struct {
+	// User ID of the channel to receive chat message delete events for.
+	BroadcasterUserID string `json:"broadcaster_user_id"`
+	// The user ID to read chat as.
+	UserID string `json:"user_id"`
+}
+
+type ConditionChannelChatNotification struct {
+	BroadcasterUserID string `json:"broadcaster_user_id"`
+	// The user ID to read chat as.
+	UserID string `json:"user_id,omitempty"`
+}

--- a/conditions.go
+++ b/conditions.go
@@ -215,5 +215,5 @@ type ConditionChannelChatNotification struct {
 	// User ID of the channel to receive chat notification events for.
 	BroadcasterUserID string `json:"broadcaster_user_id"`
 	// The user ID to read chat as.
-	UserID string `json:"user_id,omitempty"`
+	UserID string `json:"user_id"`
 }

--- a/events.go
+++ b/events.go
@@ -790,18 +790,18 @@ type EventUserUpdate struct {
 type EventChannelChatClear struct {
 	// 	The broadcaster user ID.
 	BroadcasterUserID string `json:"broadcaster_user_id"`
-	// The broadcaster user login.
+	// The broadcaster display name.
 	BroadcasterUserName string `json:"broadcaster_user_name"`
-	// The broadcaster user display name.
+	// The broadcaster login.
 	BroadcasterUserLogin string `json:"broadcaster_user_login"`
 }
 
 type EventChannelChatClearUserMessages struct {
 	// The broadcaster user ID.
 	BroadcasterUserID string `json:"broadcaster_user_id"`
-	// The broadcaster user login.
+	// The broadcaster display name.
 	BroadcasterUserName string `json:"broadcaster_user_name"`
-	// The broadcaster user display name.
+	// The broadcaster login.
 	BroadcasterUserLogin string `json:"broadcaster_user_login"`
 	// The ID of the user that was banned or put in a timeout. All of their messages are deleted.
 	TargetUserID string `json:"target_user_id"`
@@ -814,9 +814,9 @@ type EventChannelChatClearUserMessages struct {
 type EventChannelChatMessageDelete struct {
 	// The broadcaster user ID.
 	BroadcasterUserID string `json:"broadcaster_user_id"`
-	// The broadcaster user login.
+	// The broadcaster display name.
 	BroadcasterUserName string `json:"broadcaster_user_name"`
-	// The broadcaster user display name.
+	// The broadcaster login.
 	BroadcasterUserLogin string `json:"broadcaster_user_login"`
 	// The ID of the user whose message was deleted.
 	TargetUserID string `json:"target_user_id"`
@@ -824,52 +824,48 @@ type EventChannelChatMessageDelete struct {
 	TargetUserName string `json:"target_user_name"`
 	// The user login of the user whose message was deleted.
 	TargetUserLogin string `json:"target_user_login"`
+	// A UUID that identifies the message that was removed.
+	MessageID string `json:"message_id"`
 }
 
 type EventChannelChatNotification struct {
-	// Name of the event
-	Name string `json:"name"`
-	// Type of the event
-	Type string `json:"type"`
-	// Description of the event
-	Description string `json:"description"`
-	// The broadcaster user ID
+	// The broadcaster user ID.
 	BroadcasterUserID string `json:"broadcaster_user_id"`
-	// The broadcaster display name
+	// The broadcaster display name.
 	BroadcasterUserName string `json:"broadcaster_user_name"`
-	// The broadcaster login
+	// The broadcaster login.
 	BroadcasterUserLogin string `json:"broadcaster_user_login"`
-	// The user ID of the user that sent the message
+	// The user ID of the user that sent the message.
 	ChatterUserID string `json:"chatter_user_id"`
-	// The user name of the user that sent the message
+	// The user name of the user that sent the message.
 	ChatterUserName string `json:"chatter_user_name"`
-	// The user login of the user that sent the message
+	// The user login of the user that sent the message.
 	ChatterUserLogin string `json:"chatter_user_login"`
-	// Whether or not the chatter is anonymous
+	// Whether or not the chatter is anonymous.
 	ChatterIsAnonymous bool `json:"chatter_is_anonymous"`
-	// The color of the user’s name in the chat room
+	// The color of the user’s name in the chat room.
 	Color string `json:"color"`
-	// List of chat badges
+	// List of chat badges.
 	Badges []ChatNotificationBadge `json:"badges"`
-	// The message Twitch shows in the chat room for this notice
+	// The message Twitch shows in the chat room for this notice.
 	SystemMessage string `json:"system_message"`
-	// A UUID that identifies the message
+	// A UUID that identifies the message.
 	MessageID string `json:"message_id"`
 	// The structured chat message
 	Message ChatNotificationMessage `json:"message"`
 	// The type of notice. Possible values are:
-	// sub
-	// resub
-	// sub_gift
-	// community_sub_gift
-	// gift_paid_upgrade
-	// prime_paid_upgrade
-	// raid
-	// unraid
-	// pay_it_forward
-	// announcement
-	// bits_badge_tier
-	// charity_donation
+	//  - sub
+	//  - resub
+	//  - sub_gift
+	//  - community_sub_gift
+	//  - gift_paid_upgrade
+	//  - prime_paid_upgrade
+	//  - raid
+	//  - unraid
+	//  - pay_it_forward
+	//  - announcement
+	//  - bits_badge_tier
+	//  - charity_donation
 	NoticeType string `json:"notice_type"`
 	// Information about the sub event. Null if notice_type is not sub.
 	Sub *ChatNotificationSubEvent `json:"sub,omitempty"`
@@ -918,10 +914,10 @@ type ChatNotificationMessage struct {
 // ChatNotificationMessageFragment represents a fragment of a chat message.
 type ChatNotificationMessageFragment struct {
 	// The type of message fragment. Possible values:
-	// text
-	// cheermote
-	// emote
-	// mention
+	//  - text
+	//  - cheermote
+	//  - emote
+	//  - mention
 	Type string `json:"type"`
 	// Message text in fragment
 	Text string `json:"text"`
@@ -952,8 +948,8 @@ type ChatNotificationMessageFragmentEmote struct {
 	// The ID of the broadcaster who owns the emote.
 	OwnerID string `json:"owner_id"`
 	// The formats that the emote is available in. For example, if the emote is available only as a static PNG, the array contains only static. But if the emote is available as a static PNG and an animated GIF, the array contains static and animated. The possible formats are:
-	// animated — An animated GIF is available for this emote.
-	// static — A static PNG file is available for this emote.
+	//  - animated — An animated GIF is available for this emote.
+	//  - static — A static PNG file is available for this emote.
 	Format []string `json:"format"`
 }
 
@@ -970,9 +966,9 @@ type ChatNotificationMessageFragmentMention struct {
 // ChatNotificationSubEvent SubEvent represents information about the sub event.
 type ChatNotificationSubEvent struct {
 	// The type of subscription plan being used. Possible values are:
-	// 1000 — First level of paid or Prime subscription
-	// 2000 — Second level of paid subscription
-	// 3000 — Third level of paid subscription
+	//  - 1000 — First level of paid or Prime subscription
+	//  - 2000 — Second level of paid subscription
+	//  - 3000 — Third level of paid subscription
 	SubTier string `json:"sub_tier"`
 
 	// Indicates if the subscription was obtained through Amazon Prime.
@@ -994,9 +990,9 @@ type ChatNotificationResubEvent struct {
 	StreakMonths int `json:"streak_months,omitempty"`
 
 	// The type of subscription plan being used. Possible values are:
-	// 1000 — First level of paid or Prime subscription
-	// 2000 — Second level of paid subscription
-	// 3000 — Third level of paid subscription
+	//  - 1000 — First level of paid or Prime subscription
+	//  - 2000 — Second level of paid subscription
+	//  - 3000 — Third level of paid subscription
 	SubTier string `json:"sub_tier"`
 
 	// Indicates if the resub was obtained through Amazon Prime.
@@ -1036,9 +1032,9 @@ type ChatNotificationSubGiftEvent struct {
 	RecipientUserLogin string `json:"recipient_user_login"`
 
 	// The type of subscription plan being used. Possible values are:
-	// 1000 — First level of paid subscription
-	// 2000 — Second level of paid subscription
-	// 3000 — Third level of paid subscription
+	//  - 1000 — First level of paid subscription
+	//  - 2000 — Second level of paid subscription
+	//  - 3000 — Third level of paid subscription
 	SubTier string `json:"sub_tier"`
 
 	// Optional. The ID of the associated community gift. Null if not associated with a community gift.
@@ -1054,9 +1050,9 @@ type ChatNotificationCommunitySubGiftEvent struct {
 	Total int `json:"total"`
 
 	// The type of subscription plan being used. Possible values are:
-	// 1000 — First level of paid subscription
-	// 2000 — Second level of paid subscription
-	// 3000 — Third level of paid subscription
+	//  - 1000 — First level of paid subscription
+	//  - 2000 — Second level of paid subscription
+	//  - 3000 — Third level of paid subscription
 	SubTier string `json:"sub_tier"`
 
 	// Optional. The amount of gifts the gifter has given in this channel. Null if anonymous.
@@ -1081,9 +1077,9 @@ type ChatNotificationGiftPaidUpgradeEvent struct {
 // ChatNotificationPrimePaidUpgradeEvent represents information about the Prime gift paid upgrade event.
 type ChatNotificationPrimePaidUpgradeEvent struct {
 	// The type of subscription plan being used. Possible values are:
-	// 1000 — First level of paid subscription
-	// 2000 — Second level of paid subscription
-	// 3000 — Third level of paid subscription
+	//  - 1000 — First level of paid subscription
+	//  - 2000 — Second level of paid subscription
+	//  - 3000 — Third level of paid subscription
 	SubTier string `json:"sub_tier"`
 }
 

--- a/events.go
+++ b/events.go
@@ -826,7 +826,7 @@ type EventChannelChatMessageDelete struct {
 	TargetUserLogin string `json:"target_user_login"`
 }
 
-type EventChatNotification struct {
+type EventChannelChatNotification struct {
 	// Name of the event
 	Name string `json:"name"`
 	// Type of the event

--- a/events.go
+++ b/events.go
@@ -786,3 +786,375 @@ type EventUserUpdate struct {
 	// The user’s description.
 	Description string `json:"description"`
 }
+
+type EventChannelChatClear struct {
+	// 	The broadcaster user ID.
+	BroadcasterUserID string `json:"broadcaster_user_id"`
+	// The broadcaster user login.
+	BroadcasterUserName string `json:"broadcaster_user_name"`
+	// The broadcaster user display name.
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+}
+
+type EventChannelChatClearUserMessages struct {
+	// The broadcaster user ID.
+	BroadcasterUserID string `json:"broadcaster_user_id"`
+	// The broadcaster user login.
+	BroadcasterUserName string `json:"broadcaster_user_name"`
+	// The broadcaster user display name.
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	// The ID of the user that was banned or put in a timeout. All of their messages are deleted.
+	TargetUserID string `json:"target_user_id"`
+	// The user name of the user that was banned or put in a timeout.
+	TargetUserName string `json:"target_user_name"`
+	// The user login of the user that was banned or put in a timeout.
+	TargetUserLogin string `json:"target_user_login"`
+}
+
+type EventChannelChatMessageDelete struct {
+	// The broadcaster user ID.
+	BroadcasterUserID string `json:"broadcaster_user_id"`
+	// The broadcaster user login.
+	BroadcasterUserName string `json:"broadcaster_user_name"`
+	// The broadcaster user display name.
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	// The ID of the user whose message was deleted.
+	TargetUserID string `json:"target_user_id"`
+	// The user name of the user whose message was deleted.
+	TargetUserName string `json:"target_user_name"`
+	// The user login of the user whose message was deleted.
+	TargetUserLogin string `json:"target_user_login"`
+}
+
+type EventChatNotification struct {
+	// Name of the event
+	Name string `json:"name"`
+	// Type of the event
+	Type string `json:"type"`
+	// Description of the event
+	Description string `json:"description"`
+	// The broadcaster user ID
+	BroadcasterUserID string `json:"broadcaster_user_id"`
+	// The broadcaster display name
+	BroadcasterUserName string `json:"broadcaster_user_name"`
+	// The broadcaster login
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	// The user ID of the user that sent the message
+	ChatterUserID string `json:"chatter_user_id"`
+	// The user name of the user that sent the message
+	ChatterUserName string `json:"chatter_user_name"`
+	// The user login of the user that sent the message
+	ChatterUserLogin string `json:"chatter_user_login"`
+	// Whether or not the chatter is anonymous
+	ChatterIsAnonymous bool `json:"chatter_is_anonymous"`
+	// The color of the user’s name in the chat room
+	Color string `json:"color"`
+	// List of chat badges
+	Badges []ChatNotificationBadge `json:"badges"`
+	// The message Twitch shows in the chat room for this notice
+	SystemMessage string `json:"system_message"`
+	// A UUID that identifies the message
+	MessageID string `json:"message_id"`
+	// The structured chat message
+	Message ChatNotificationMessage `json:"message"`
+	// The type of notice. Possible values are:
+	// sub
+	// resub
+	// sub_gift
+	// community_sub_gift
+	// gift_paid_upgrade
+	// prime_paid_upgrade
+	// raid
+	// unraid
+	// pay_it_forward
+	// announcement
+	// bits_badge_tier
+	// charity_donation
+	NoticeType string `json:"notice_type"`
+	// Information about the sub event. Null if notice_type is not sub.
+	Sub *ChatNotificationSubEvent `json:"sub,omitempty"`
+	// Information about the resub event. Null if notice_type is not resub.
+	Resub *ChatNotificationResubEvent `json:"resub,omitempty"`
+	// Information about the gift sub event. Null if notice_type is not sub_gift.
+	SubGift *ChatNotificationSubGiftEvent `json:"sub_gift,omitempty"`
+	// Information about the community gift sub event. Null if notice_type is not community_sub_gift.
+	CommunitySubGift *ChatNotificationCommunitySubGiftEvent `json:"community_sub_gift,omitempty"`
+	// Information about the community gift paid upgrade event. Null if notice_type is not gift_paid_upgrade.
+	GiftPaidUpgrade *ChatNotificationGiftPaidUpgradeEvent `json:"gift_paid_upgrade,omitempty"`
+	// Information about the Prime gift paid upgrade event. Null if notice_type is not prime_paid_upgrade.
+	PrimePaidUpgrade *ChatNotificationPrimePaidUpgradeEvent `json:"prime_paid_upgrade,omitempty"`
+	// Information about the raid event. Null if notice_type is not raid.
+	Raid *ChatNotificationRaidEvent `json:"raid,omitempty"`
+	// Returns an empty payload if notice_type is unraid, otherwise returns null.
+	Unraid *ChatNotificationUnraidEvent `json:"unraid,omitempty"`
+	// Information about the pay it forward event. Null if notice_type is not pay_it_forward.
+	PayItForward *ChatNotificationPayItForwardEvent `json:"pay_it_forward,omitempty"`
+	// Information about the announcement event. Null if notice_type is not announcement.
+	Announcement *ChatNotificationAnnouncementEvent `json:"announcement,omitempty"`
+	// Information about the charity donation event. Null if notice_type is not charity_donation.
+	CharityDonation *ChatNotificationCharityDonationEvent `json:"charity_donation,omitempty"`
+	// Information about the bits badge tier event. Null if notice_type is not bits_badge_tier.
+	BitsBadgeTier *ChatNotificationBitsBadgeTierEvent `json:"bits_badge_tier,omitempty"`
+}
+
+// ChatNotificationBadge ChatBadge represents a chat badge.
+type ChatNotificationBadge struct {
+	// An ID that identifies this set of chat badges. For example, Bits or Subscriber.
+	SetID string `json:"set_id"`
+	// An ID that identifies this version of the badge. The ID can be any value. For example, for Bits, the ID is the Bits tier level, but for World of Warcraft, it could be Alliance or Horde.
+	ID string `json:"id"`
+	// Contains metadata related to the chat badges in the badges tag. Currently, this tag contains metadata only for subscriber badges, to indicate the number of months the user has been a subscriber.
+	Info string `json:"info"`
+}
+
+// ChatNotificationMessage ChatMessage represents a structured chat message.
+type ChatNotificationMessage struct {
+	// The chat message in plain text.
+	Text string `json:"text"`
+	// Ordered list of chat message fragments.
+	Fragments []ChatNotificationMessageFragment `json:"fragments"`
+}
+
+// ChatNotificationMessageFragment represents a fragment of a chat message.
+type ChatNotificationMessageFragment struct {
+	// The type of message fragment. Possible values:
+	// text
+	// cheermote
+	// emote
+	// mention
+	Type string `json:"type"`
+	// Message text in fragment
+	Text string `json:"text"`
+	// Optional. Metadata pertaining to the cheermote.
+	Cheermote *ChatNotificationMessageFragmentCheermote `json:"cheermote,omitempty"`
+	// Optional. Metadata pertaining to the emote.
+	Emote *ChatNotificationMessageFragmentEmote `json:"emote,omitempty"`
+	// Optional. Metadata pertaining to the mention.
+	Mention *ChatNotificationMessageFragmentMention `json:"mention,omitempty"`
+}
+
+// ChatNotificationMessageFragmentCheermote represents metadata pertaining to a cheermote.
+type ChatNotificationMessageFragmentCheermote struct {
+	// The name portion of the ChatNotificationMessageFragmentCheermote string that you use in chat to cheer Bits. The full ChatNotificationMessageFragmentCheermote string is the concatenation of {prefix} + {number of Bits}. For example, if the prefix is “Cheer” and you want to cheer 100 Bits, the full ChatNotificationMessageFragmentCheermote string is Cheer100. When the ChatNotificationMessageFragmentCheermote string is entered in chat, Twitch converts it to the image associated with the Bits tier that was cheered.
+	Prefix string `json:"prefix"`
+	// The amount of bits cheered.
+	Bits int `json:"bits"`
+	// The tier level of the cheermote.
+	Tier int `json:"tier"`
+}
+
+// ChatNotificationMessageFragmentEmote represents metadata pertaining to an emote.
+type ChatNotificationMessageFragmentEmote struct {
+	// An ID that uniquely identifies this emote.
+	ID string `json:"id"`
+	// An ID that identifies the emote set that the emote belongs to.
+	EmoteSetID string `json:"emote_set_id"`
+	// The ID of the broadcaster who owns the emote.
+	OwnerID string `json:"owner_id"`
+	// The formats that the emote is available in. For example, if the emote is available only as a static PNG, the array contains only static. But if the emote is available as a static PNG and an animated GIF, the array contains static and animated. The possible formats are:
+	// animated — An animated GIF is available for this emote.
+	// static — A static PNG file is available for this emote.
+	Format []string `json:"format"`
+}
+
+// ChatNotificationMessageFragmentMention represents metadata pertaining to a mention.
+type ChatNotificationMessageFragmentMention struct {
+	// The user ID of the mentioned user.
+	UserID string `json:"user_id"`
+	// The user name of the mentioned user.
+	UserName string `json:"user_name"`
+	// The user login of the mentioned user.
+	UserLogin string `json:"user_login"`
+}
+
+// ChatNotificationSubEvent SubEvent represents information about the sub event.
+type ChatNotificationSubEvent struct {
+	// The type of subscription plan being used. Possible values are:
+	// 1000 — First level of paid or Prime subscription
+	// 2000 — Second level of paid subscription
+	// 3000 — Third level of paid subscription
+	SubTier string `json:"sub_tier"`
+
+	// Indicates if the subscription was obtained through Amazon Prime.
+	IsPrime bool `json:"is_prime"`
+
+	// The number of months the subscription is for.
+	DurationMonths int `json:"duration_months"`
+}
+
+// ChatNotificationResubEvent represents information about the resub event.
+type ChatNotificationResubEvent struct {
+	// The total number of months the user has subscribed.
+	CumulativeMonths int `json:"cumulative_months"`
+
+	// The number of months the subscription is for.
+	DurationMonths int `json:"duration_months"`
+
+	// Optional. The number of consecutive months the user has subscribed.
+	StreakMonths int `json:"streak_months,omitempty"`
+
+	// The type of subscription plan being used. Possible values are:
+	// 1000 — First level of paid or Prime subscription
+	// 2000 — Second level of paid subscription
+	// 3000 — Third level of paid subscription
+	SubTier string `json:"sub_tier"`
+
+	// Indicates if the resub was obtained through Amazon Prime.
+	IsPrime bool `json:"is_prime"`
+
+	// Whether or not the resub was a result of a gift.
+	IsGift bool `json:"is_gift"`
+
+	// Optional. Whether or not the gift was anonymous.
+	GifterIsAnonymous bool `json:"gifter_is_anonymous,omitempty"`
+
+	// Optional. The user ID of the subscription gifter. Null if anonymous.
+	GifterUserID string `json:"gifter_user_id,omitempty"`
+
+	// Optional. The user name of the subscription gifter. Null if anonymous.
+	GifterUserName string `json:"gifter_user_name,omitempty"`
+
+	// Optional. The user login of the subscription gifter. Null if anonymous.
+	GifterUserLogin string `json:"gifter_user_login,omitempty"`
+}
+
+// ChatNotificationSubGiftEvent represents information about the gift sub event.
+type ChatNotificationSubGiftEvent struct {
+	// The number of months the subscription is for.
+	DurationMonths int `json:"duration_months"`
+
+	// Optional. The amount of gifts the gifter has given in this channel. Null if anonymous.
+	CumulativeTotal int `json:"cumulative_total,omitempty"`
+
+	// The user ID of the subscription gift recipient.
+	RecipientUserID string `json:"recipient_user_id"`
+
+	// The user name of the subscription gift recipient.
+	RecipientUserName string `json:"recipient_user_name"`
+
+	// The user login of the subscription gift recipient.
+	RecipientUserLogin string `json:"recipient_user_login"`
+
+	// The type of subscription plan being used. Possible values are:
+	// 1000 — First level of paid subscription
+	// 2000 — Second level of paid subscription
+	// 3000 — Third level of paid subscription
+	SubTier string `json:"sub_tier"`
+
+	// Optional. The ID of the associated community gift. Null if not associated with a community gift.
+	CommunityGiftID string `json:"community_gift_id,omitempty"`
+}
+
+// ChatNotificationCommunitySubGiftEvent represents information about the community gift sub event.
+type ChatNotificationCommunitySubGiftEvent struct {
+	// The ID of the associated community gift.
+	ID string `json:"id"`
+
+	// Number of subscriptions being gifted.
+	Total int `json:"total"`
+
+	// The type of subscription plan being used. Possible values are:
+	// 1000 — First level of paid subscription
+	// 2000 — Second level of paid subscription
+	// 3000 — Third level of paid subscription
+	SubTier string `json:"sub_tier"`
+
+	// Optional. The amount of gifts the gifter has given in this channel. Null if anonymous.
+	CumulativeTotal int `json:"cumulative_total,omitempty"`
+}
+
+// ChatNotificationGiftPaidUpgradeEvent represents information about the community gift paid upgrade event.
+type ChatNotificationGiftPaidUpgradeEvent struct {
+	// Whether the gift was given anonymously.
+	GifterIsAnonymous bool `json:"gifter_is_anonymous"`
+
+	// Optional. The user ID of the user who gifted the subscription. Null if anonymous.
+	GifterUserID string `json:"gifter_user_id,omitempty"`
+
+	// Optional. The user name of the user who gifted the subscription. Null if anonymous.
+	GifterUserName string `json:"gifter_user_name,omitempty"`
+
+	// Optional. The user login of the user who gifted the subscription. Null if anonymous.
+	GifterUserLogin string `json:"gifter_user_login,omitempty"`
+}
+
+// ChatNotificationPrimePaidUpgradeEvent represents information about the Prime gift paid upgrade event.
+type ChatNotificationPrimePaidUpgradeEvent struct {
+	// The type of subscription plan being used. Possible values are:
+	// 1000 — First level of paid subscription
+	// 2000 — Second level of paid subscription
+	// 3000 — Third level of paid subscription
+	SubTier string `json:"sub_tier"`
+}
+
+// ChatNotificationRaidEvent represents information about the raid event.
+type ChatNotificationRaidEvent struct {
+	// The user ID of the broadcaster raiding this channel.
+	UserID string `json:"user_id"`
+
+	// The user name of the broadcaster raiding this channel.
+	UserName string `json:"user_name"`
+
+	// The login name of the broadcaster raiding this channel.
+	UserLogin string `json:"user_login"`
+
+	// The number of viewers raiding this channel from the broadcaster’s channel.
+	ViewerCount int `json:"viewer_count"`
+
+	// Profile image URL of the broadcaster raiding this channel.
+	ProfileImageURL string `json:"profile_image_url"`
+}
+
+// ChatNotificationUnraidEvent represents an empty payload for the unraid event.
+type ChatNotificationUnraidEvent struct {
+}
+
+// ChatNotificationPayItForwardEvent represents information about the pay it forward event.
+type ChatNotificationPayItForwardEvent struct {
+	// Whether the gift was given anonymously.
+	GifterIsAnonymous bool `json:"gifter_is_anonymous"`
+
+	// Optional. The user ID of the user who gifted the subscription. Null if anonymous.
+	GifterUserID string `json:"gifter_user_id,omitempty"`
+
+	// Optional. The user name of the user who gifted the subscription. Null if anonymous.
+	GifterUserName string `json:"gifter_user_name,omitempty"`
+
+	// Optional. The user login of the user who gifted the subscription. Null if anonymous.
+	GifterUserLogin string `json:"gifter_user_login,omitempty"`
+}
+
+// ChatNotificationAnnouncementEvent represents information about the announcement event.
+type ChatNotificationAnnouncementEvent struct {
+	// Color of the announcement.
+	Color string `json:"color"`
+}
+
+// ChatNotificationCharityDonationEvent represents information about the charity donation event.
+type ChatNotificationCharityDonationEvent struct {
+	// Name of the charity.
+	CharityName string `json:"charity_name"`
+
+	// An object that contains the amount of money that the user paid.
+	Amount ChatNotificationCharityDonationEventDonationAmount `json:"amount"`
+}
+
+// ChatNotificationCharityDonationEventDonationAmount represents the amount of money that the user paid.
+type ChatNotificationCharityDonationEventDonationAmount struct {
+	// The monetary amount. The amount is specified in the currency’s minor unit.
+	// For example, the minor units for USD is cents, so if the amount is $5.50 USD, value is set to 550.
+	Value int `json:"value"`
+
+	// The number of decimal places used by the currency.
+	// For example, USD uses two decimal places.
+	DecimalPlaces int `json:"decimal_places"`
+
+	// The ISO-4217 three-letter currency code that identifies the type of currency in value.
+	Currency string `json:"currency"`
+}
+
+// ChatNotificationBitsBadgeTierEvent represents information about the bits badge tier event.
+type ChatNotificationBitsBadgeTierEvent struct {
+	// The tier of the Bits badge the user just earned. For example, 100, 1000, or 10000.
+	Tier int `json:"tier"`
+}

--- a/objects.go
+++ b/objects.go
@@ -106,9 +106,9 @@ type Message struct {
 }
 
 type Emote struct {
-	// The index of where the Emote starts in the text.
+	// The index of where the ChatNotificationMessageFragmentEmote starts in the text.
 	Begin int `json:"begin"`
-	// The index of where the Emote ends in the text.
+	// The index of where the ChatNotificationMessageFragmentEmote ends in the text.
 	End int `json:"end"`
 	// The emote ID.
 	ID string `json:"id"`

--- a/subscription.go
+++ b/subscription.go
@@ -41,10 +41,7 @@ func (s *Subscription) ConditionChannelSubscriptionEnd() (*ConditionChannelSubsc
 	}
 }
 
-func (s *Subscription) ConditionChannelSubscriptionGift() (
-	*ConditionChannelSubscriptionGift,
-	error,
-) {
+func (s *Subscription) ConditionChannelSubscriptionGift() (*ConditionChannelSubscriptionGift, error) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -53,10 +50,7 @@ func (s *Subscription) ConditionChannelSubscriptionGift() (
 	}
 }
 
-func (s *Subscription) ConditionChannelSubscriptionMessage() (
-	*ConditionChannelSubscriptionMessage,
-	error,
-) {
+func (s *Subscription) ConditionChannelSubscriptionMessage() (*ConditionChannelSubscriptionMessage, error) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -137,10 +131,7 @@ func (s *Subscription) ConditionChannelPointsRewardAdd() (*ConditionChannelPoint
 	}
 }
 
-func (s *Subscription) ConditionChannelPointsRewardUpdate() (
-	*ConditionChannelPointsRewardUpdate,
-	error,
-) {
+func (s *Subscription) ConditionChannelPointsRewardUpdate() (*ConditionChannelPointsRewardUpdate, error) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -149,10 +140,7 @@ func (s *Subscription) ConditionChannelPointsRewardUpdate() (
 	}
 }
 
-func (s *Subscription) ConditionChannelPointsRewardRemove() (
-	*ConditionChannelPointsRewardRemove,
-	error,
-) {
+func (s *Subscription) ConditionChannelPointsRewardRemove() (*ConditionChannelPointsRewardRemove, error) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -161,10 +149,7 @@ func (s *Subscription) ConditionChannelPointsRewardRemove() (
 	}
 }
 
-func (s *Subscription) ConditionChannelPointsRewardRedemptionAdd() (
-	*ConditionChannelPointsRewardRedemptionAdd,
-	error,
-) {
+func (s *Subscription) ConditionChannelPointsRewardRedemptionAdd() (*ConditionChannelPointsRewardRedemptionAdd, error) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -173,10 +158,7 @@ func (s *Subscription) ConditionChannelPointsRewardRedemptionAdd() (
 	}
 }
 
-func (s *Subscription) ConditionChannelPointsRewardRedemptionUpdate() (
-	*ConditionChannelPointsRewardRedemptionUpdate,
-	error,
-) {
+func (s *Subscription) ConditionChannelPointsRewardRedemptionUpdate() (*ConditionChannelPointsRewardRedemptionUpdate, error) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -248,10 +230,7 @@ func (s *Subscription) ConditionDropEntitlementGrant() (*ConditionDropEntitlemen
 	}
 }
 
-func (s *Subscription) ConditionExtensionBitsTransactionCreate() (
-	*ConditionExtensionBitsTransactionCreate,
-	error,
-) {
+func (s *Subscription) ConditionExtensionBitsTransactionCreate() (*ConditionExtensionBitsTransactionCreate, error) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -323,10 +302,7 @@ func (s *Subscription) ConditionUserAuthorizationGrant() (*ConditionUserAuthoriz
 	}
 }
 
-func (s *Subscription) ConditionUserAuthorizationRevoke() (
-	*ConditionUserAuthorizationRevoke,
-	error,
-) {
+func (s *Subscription) ConditionUserAuthorizationRevoke() (*ConditionUserAuthorizationRevoke, error) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -353,10 +329,7 @@ func (s *Subscription) ConditionChannelChatClear() (*ConditionChannelChatClear, 
 	}
 }
 
-func (s *Subscription) ConditionChannelChatClearUserMessages() (
-	*ConditionChannelChatClearUserMessages,
-	error,
-) {
+func (s *Subscription) ConditionChannelChatClearUserMessages() (*ConditionChannelChatClearUserMessages, error) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -365,10 +338,7 @@ func (s *Subscription) ConditionChannelChatClearUserMessages() (
 	}
 }
 
-func (s *Subscription) ConditionChannelChatMessageDelete() (
-	*ConditionChannelChatMessageDelete,
-	error,
-) {
+func (s *Subscription) ConditionChannelChatMessageDelete() (*ConditionChannelChatMessageDelete, error) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -377,10 +347,7 @@ func (s *Subscription) ConditionChannelChatMessageDelete() (
 	}
 }
 
-func (s *Subscription) ConditionChannelChatNotification() (
-	*ConditionChannelChatNotification,
-	error,
-) {
+func (s *Subscription) ConditionChannelChatNotification() (*ConditionChannelChatNotification, error) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {

--- a/subscription.go
+++ b/subscription.go
@@ -41,7 +41,10 @@ func (s *Subscription) ConditionChannelSubscriptionEnd() (*ConditionChannelSubsc
 	}
 }
 
-func (s *Subscription) ConditionChannelSubscriptionGift() (*ConditionChannelSubscriptionGift, error) {
+func (s *Subscription) ConditionChannelSubscriptionGift() (
+	*ConditionChannelSubscriptionGift,
+	error,
+) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -50,7 +53,10 @@ func (s *Subscription) ConditionChannelSubscriptionGift() (*ConditionChannelSubs
 	}
 }
 
-func (s *Subscription) ConditionChannelSubscriptionMessage() (*ConditionChannelSubscriptionMessage, error) {
+func (s *Subscription) ConditionChannelSubscriptionMessage() (
+	*ConditionChannelSubscriptionMessage,
+	error,
+) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -131,7 +137,10 @@ func (s *Subscription) ConditionChannelPointsRewardAdd() (*ConditionChannelPoint
 	}
 }
 
-func (s *Subscription) ConditionChannelPointsRewardUpdate() (*ConditionChannelPointsRewardUpdate, error) {
+func (s *Subscription) ConditionChannelPointsRewardUpdate() (
+	*ConditionChannelPointsRewardUpdate,
+	error,
+) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -140,7 +149,10 @@ func (s *Subscription) ConditionChannelPointsRewardUpdate() (*ConditionChannelPo
 	}
 }
 
-func (s *Subscription) ConditionChannelPointsRewardRemove() (*ConditionChannelPointsRewardRemove, error) {
+func (s *Subscription) ConditionChannelPointsRewardRemove() (
+	*ConditionChannelPointsRewardRemove,
+	error,
+) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -149,7 +161,10 @@ func (s *Subscription) ConditionChannelPointsRewardRemove() (*ConditionChannelPo
 	}
 }
 
-func (s *Subscription) ConditionChannelPointsRewardRedemptionAdd() (*ConditionChannelPointsRewardRedemptionAdd, error) {
+func (s *Subscription) ConditionChannelPointsRewardRedemptionAdd() (
+	*ConditionChannelPointsRewardRedemptionAdd,
+	error,
+) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -158,7 +173,10 @@ func (s *Subscription) ConditionChannelPointsRewardRedemptionAdd() (*ConditionCh
 	}
 }
 
-func (s *Subscription) ConditionChannelPointsRewardRedemptionUpdate() (*ConditionChannelPointsRewardRedemptionUpdate, error) {
+func (s *Subscription) ConditionChannelPointsRewardRedemptionUpdate() (
+	*ConditionChannelPointsRewardRedemptionUpdate,
+	error,
+) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -230,7 +248,10 @@ func (s *Subscription) ConditionDropEntitlementGrant() (*ConditionDropEntitlemen
 	}
 }
 
-func (s *Subscription) ConditionExtensionBitsTransactionCreate() (*ConditionExtensionBitsTransactionCreate, error) {
+func (s *Subscription) ConditionExtensionBitsTransactionCreate() (
+	*ConditionExtensionBitsTransactionCreate,
+	error,
+) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -302,7 +323,10 @@ func (s *Subscription) ConditionUserAuthorizationGrant() (*ConditionUserAuthoriz
 	}
 }
 
-func (s *Subscription) ConditionUserAuthorizationRevoke() (*ConditionUserAuthorizationRevoke, error) {
+func (s *Subscription) ConditionUserAuthorizationRevoke() (
+	*ConditionUserAuthorizationRevoke,
+	error,
+) {
 	if data, err := json.Marshal(s.Condition); err != nil {
 		return nil, err
 	} else {
@@ -316,6 +340,51 @@ func (s *Subscription) ConditionUserUpdate() (*ConditionUserUpdate, error) {
 		return nil, err
 	} else {
 		var condition ConditionUserUpdate
+		return &condition, json.Unmarshal(data, &condition)
+	}
+}
+
+func (s *Subscription) ConditionChannelChatClear() (*ConditionChannelChatClear, error) {
+	if data, err := json.Marshal(s.Condition); err != nil {
+		return nil, err
+	} else {
+		var condition ConditionChannelChatClear
+		return &condition, json.Unmarshal(data, &condition)
+	}
+}
+
+func (s *Subscription) ConditionChannelChatClearUserMessages() (
+	*ConditionChannelChatClearUserMessages,
+	error,
+) {
+	if data, err := json.Marshal(s.Condition); err != nil {
+		return nil, err
+	} else {
+		var condition ConditionChannelChatClearUserMessages
+		return &condition, json.Unmarshal(data, &condition)
+	}
+}
+
+func (s *Subscription) ConditionChannelChatMessageDelete() (
+	*ConditionChannelChatMessageDelete,
+	error,
+) {
+	if data, err := json.Marshal(s.Condition); err != nil {
+		return nil, err
+	} else {
+		var condition ConditionChannelChatMessageDelete
+		return &condition, json.Unmarshal(data, &condition)
+	}
+}
+
+func (s *Subscription) ConditionChannelChatNotification() (
+	*ConditionChannelChatNotification,
+	error,
+) {
+	if data, err := json.Marshal(s.Condition); err != nil {
+		return nil, err
+	} else {
+		var condition ConditionChannelChatNotification
 		return &condition, json.Unmarshal(data, &condition)
 	}
 }


### PR DESCRIPTION
To be fair `chat notification` structs was generated via chat gpt, because payload is huge, but naming was rewritten by me. So, it requires some proper review before merge.